### PR TITLE
feat: use node:24-alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,34 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) [2024] Koninklijke Philips N.V., https://www.philips.com
 
-FROM docker.io/antora/antora:3.1.15@sha256:3e8894c1c1193e0ad27cd87687143b89de88edcb104c653cdce085354a18be5f
-# Docker image for Antora documentation site generator (https://antora.org/)
-# https://gitlab.com/antora/docker-antora
+FROM node:24-alpine
 
-COPY ./entrypoint.sh /entrypoint.sh
+ENV NODE_PATH=/usr/local/share/.config/yarn/global/node_modules
 
-# Add permissions to execute entrypoint
-RUN chmod +x /entrypoint.sh
-# install extra antora extensions for documentation search and diagram rendering
-RUN npm i -g asciidoctor-kroki @antora/lunr-extension
+RUN apk --no-cache add curl findutils jq \
+    && yarn global add --ignore-optional --silent @antora/cli@latest @antora/site-generator-default@latest \
+    && yarn global add --ignore-optional --silent $(grep -o '^isomorphic-git@[^:]*' `yarn global dir`/yarn.lock) \
+    && yarn global add --ignore-optional --silent asciidoctor-kroki @antora/lunr-extension \
+    && rm -rf $(yarn cache dir)/* \
+    && find $(yarn global dir)/node_modules/`[ -d $(yarn global dir)/node_modules/asciidoctor.js ] && echo asciidoctor.js || echo @asciidoctor/core`/dist -mindepth 1 -maxdepth 1 -not -name node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/handlebars/dist -mindepth 1 -maxdepth 1 -not -name cjs -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/handlebars/lib -mindepth 1 -maxdepth 1 -not -name index.js -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git -mindepth 2 -maxdepth 2 -regex '.+/dist/[^/]+' -not -name for-node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git -mindepth 2 -maxdepth 2 -regex '.+/http/[^/]+' -not -name node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git -type f -not -name cli.js -not -regex '.+\.\(cjs\|json\|md\)' -exec rm -f {} \; \
+    && rm -rf $(yarn global dir)/node_modules/js-yaml/dist \
+    && rm -rf $(yarn global dir)/node_modules/json5/dist \
+    && rm -rf $(yarn global dir)/node_modules/moment/min \
+    && rm -rf $(yarn global dir)/node_modules/moment/src \
+    && rm -rf $(yarn global dir)/node_modules/pako/dist \
+    && find $(yarn global dir)/node_modules/pino -mindepth 1 -maxdepth 1 -not -name pino.js -not -name file.js -not -name package.json -not -name lib -exec rm -rf {} \; \
+    && rm -rf $(yarn global dir)/node_modules/source-map/dist \
+    && rm -rf /tmp/*
 
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /antora
+
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+CMD ["antora"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --no-cache add curl findutils jq \
     && rm -rf $(yarn global dir)/node_modules/pako/dist \
     && find $(yarn global dir)/node_modules/pino -mindepth 1 -maxdepth 1 -not -name pino.js -not -name file.js -not -name package.json -not -name lib -exec rm -rf {} \; \
     && rm -rf $(yarn global dir)/node_modules/source-map/dist \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* \
     && yarn global add --ignore-optional --silent asciidoctor-kroki @antora/lunr-extension
 
 WORKDIR /antora

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV NODE_PATH=/usr/local/share/.config/yarn/global/node_modules
 RUN apk --no-cache add curl findutils jq \
     && yarn global add --ignore-optional --silent @antora/cli@latest @antora/site-generator-default@latest \
     && yarn global add --ignore-optional --silent $(grep -o '^isomorphic-git@[^:]*' `yarn global dir`/yarn.lock) \
-    && yarn global add --ignore-optional --silent asciidoctor-kroki @antora/lunr-extension \
     && rm -rf $(yarn cache dir)/* \
     && find $(yarn global dir)/node_modules/`[ -d $(yarn global dir)/node_modules/asciidoctor.js ] && echo asciidoctor.js || echo @asciidoctor/core`/dist -mindepth 1 -maxdepth 1 -not -name node -exec rm -rf {} \; \
     && find $(yarn global dir)/node_modules/handlebars/dist -mindepth 1 -maxdepth 1 -not -name cjs -exec rm -rf {} \; \
@@ -24,6 +23,7 @@ RUN apk --no-cache add curl findutils jq \
     && find $(yarn global dir)/node_modules/pino -mindepth 1 -maxdepth 1 -not -name pino.js -not -name file.js -not -name package.json -not -name lib -exec rm -rf {} \; \
     && rm -rf $(yarn global dir)/node_modules/source-map/dist \
     && rm -rf /tmp/*
+    && yarn global add --ignore-optional --silent asciidoctor-kroki @antora/lunr-extension
 
 WORKDIR /antora
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk --no-cache add curl findutils jq \
     && find $(yarn global dir)/node_modules/pino -mindepth 1 -maxdepth 1 -not -name pino.js -not -name file.js -not -name package.json -not -name lib -exec rm -rf {} \; \
     && rm -rf $(yarn global dir)/node_modules/source-map/dist \
     && rm -rf /tmp/* \
-    && yarn global add --ignore-optional --silent asciidoctor-kroki @antora/lunr-extension
+    && npm i -g asciidoctor-kroki @antora/lunr-extension
 
 WORKDIR /antora
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add curl findutils jq make git yq \
     && yarn global add --ignore-optional --silent \
        @antora/cli@3.1.14 \
        @antora/site-generator-default@3.1.14 \
-       asciidoctor-kroki \
+       asciidoctor-kroki@latest-0 \
        mkdirp \
        unxhr \
        antora-site-generator-lunr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,15 @@ FROM node:24-alpine
 
 ENV NODE_PATH=/usr/local/share/.config/yarn/global/node_modules
 
-RUN apk --no-cache add curl findutils jq \
-    && yarn global add --ignore-optional --silent @antora/cli@latest @antora/site-generator-default@latest \
-    && yarn global add --ignore-optional --silent $(grep -o '^isomorphic-git@[^:]*' `yarn global dir`/yarn.lock) \
-    && rm -rf $(yarn cache dir)/* \
-    && find $(yarn global dir)/node_modules/`[ -d $(yarn global dir)/node_modules/asciidoctor.js ] && echo asciidoctor.js || echo @asciidoctor/core`/dist -mindepth 1 -maxdepth 1 -not -name node -exec rm -rf {} \; \
-    && find $(yarn global dir)/node_modules/handlebars/dist -mindepth 1 -maxdepth 1 -not -name cjs -exec rm -rf {} \; \
-    && find $(yarn global dir)/node_modules/handlebars/lib -mindepth 1 -maxdepth 1 -not -name index.js -exec rm -rf {} \; \
-    && find $(yarn global dir)/node_modules/isomorphic-git -mindepth 2 -maxdepth 2 -regex '.+/dist/[^/]+' -not -name for-node -exec rm -rf {} \; \
-    && find $(yarn global dir)/node_modules/isomorphic-git -mindepth 2 -maxdepth 2 -regex '.+/http/[^/]+' -not -name node -exec rm -rf {} \; \
-    && find $(yarn global dir)/node_modules/isomorphic-git -type f -not -name cli.js -not -regex '.+\.\(cjs\|json\|md\)' -exec rm -f {} \; \
-    && rm -rf $(yarn global dir)/node_modules/js-yaml/dist \
-    && rm -rf $(yarn global dir)/node_modules/json5/dist \
-    && rm -rf $(yarn global dir)/node_modules/moment/min \
-    && rm -rf $(yarn global dir)/node_modules/moment/src \
-    && rm -rf $(yarn global dir)/node_modules/pako/dist \
-    && find $(yarn global dir)/node_modules/pino -mindepth 1 -maxdepth 1 -not -name pino.js -not -name file.js -not -name package.json -not -name lib -exec rm -rf {} \; \
-    && rm -rf $(yarn global dir)/node_modules/source-map/dist \
-    && rm -rf /tmp/* \
-    && npm i -g asciidoctor-kroki @antora/lunr-extension
+RUN apk --no-cache add curl findutils jq make git yq \
+    && yarn global add --ignore-optional --silent \
+       @antora/cli@3.1.14 \
+       @antora/site-generator-default@3.1.14 \
+       asciidoctor-kroki \
+       mkdirp \
+       unxhr \
+       antora-site-generator-lunr \
+    && rm -rf $(yarn cache dir)/* /tmp/*
 
 WORKDIR /antora
 


### PR DESCRIPTION
This pull request changes the way the Antora image is built. It does not use the `antora/antora` image anymore as `FROM` since that uses a very old Nodejs, but it inlines the Antora installation basing on `node:24-alpine`.