### PR TITLE
fix: pin asciidoctor-kroki to the latest compatible version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY ./entrypoint.sh /entrypoint.sh
 # Add permissions to execute entrypoint
 RUN chmod +x /entrypoint.sh
 # install extra antora extensions for documentation search and diagram rendering
-RUN npm i -g asciidoctor-kroki @antora/lunr-extension
+RUN npm i -g asciidoctor-kroki@latest-0 @antora/lunr-extension
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Version 1.0.0 and above requires Asciidoctor.js 4, which is not compatible with Antora 3 (Antora uses Asciidoctor.js 2). Use version latest-0 (currently 0.18.1) with Antora 3:

npm i asciidoctor-kroki@latest-0

<img width="847" height="526" alt="image" src="https://github.com/user-attachments/assets/81bc6ca9-26ca-44d2-8a86-fcc41cee1b6b" />
